### PR TITLE
Allow opening of Excel files used by other processes

### DIFF
--- a/APLSource/Main/OpenExcelFile.aplf
+++ b/APLSource/Main/OpenExcelFile.aplf
@@ -1,6 +1,8 @@
  OpenExcelFile←{
      ⍝ ⍵ ←→ File Name
      ⍝ ← ←→ .NET ZipArchive
-     ⎕USING←'System.IO.Compression,System.IO.Compression.FileSystem.dll'
-     ZipFile.OpenRead⊂⍵
+     ⎕USING←'System.IO.Compression,System.IO.Compression.dll'
+     ⎕USING,←⊂'System.IO,System.Runtime.dll'
+     fs←⎕NEW FileStream(⍵ FileMode.Open FileAccess.Read FileShare.ReadWrite)
+     ⎕NEW ZipArchive(fs ZipArchiveMode.Read)
  }


### PR DESCRIPTION
ZipFile.OpenRead does not truly open a file in ReadOnly mode. This change explicitly reads the file in a ReadOnly mode. See Issue #11